### PR TITLE
Automated toolkit creating

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,27 @@ git submodule update --init vendor/decomp-permuter
 
 - `ANTHROPIC_API_KEY` environment variable set
 
+### Experimental Project Scaffolding (GC/Wii via decomp-toolkit)
+
+Mizuchi can now scaffold a GC/Wii project from [`encounter/dtk-template`](https://github.com/encounter/dtk-template):
+
+```bash
+npm run dev -- --init-toolkit dtk --game-id GLZE01 --platform gc --project-dir ./windwaker-dtk
+```
+
+Currently it just:
+
+- Clones `dtk-template`
+- Renames `orig/GAMEID` and `config/GAMEID`
+- Rewrites the `GAMEID` placeholders in core config files (`configure.py`, `config.yml`, `build.sha1`)
+- Re-initializes a fresh local git repo
+
+Maybe later?
+
+- Disc extraction
+- `config.yml` game-specific tuning
+- `build.sha1` generation (`dtk shasum ...`)
+
 ## Quick Start
 
 1. **Create a configuration file**:

--- a/src/cli/toolkit-init.spec.ts
+++ b/src/cli/toolkit-init.spec.ts
@@ -1,0 +1,92 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ToolkitInitError, customizeDtkTemplateProject, parseToolkitInitRequest } from './toolkit-init.js';
+
+describe('toolkit-init', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mizuchi-toolkit-init-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('parseToolkitInitRequest', () => {
+    it('returns null when toolkit init options are not used', () => {
+      expect(parseToolkitInitRequest({})).toBeNull();
+    });
+
+    it('normalizes the game ID and provides defaults', () => {
+      const request = parseToolkitInitRequest({
+        initToolkit: 'dtk',
+        gameId: 'glze01',
+      });
+
+      expect(request).toEqual({
+        toolkit: 'dtk',
+        gameId: 'GLZE01',
+        projectDir: './glze01-dtk',
+        platform: 'gc',
+      });
+    });
+
+    it('throws when extra toolkit options are provided without --init-toolkit', () => {
+      expect(() =>
+        parseToolkitInitRequest({
+          gameId: 'GLZE01',
+        }),
+      ).toThrow(ToolkitInitError);
+    });
+
+    it('throws on invalid game IDs', () => {
+      expect(() =>
+        parseToolkitInitRequest({
+          initToolkit: 'dtk',
+          gameId: 'bad-id!',
+        }),
+      ).toThrow("Invalid game ID 'bad-id!'");
+    });
+  });
+
+  describe('customizeDtkTemplateProject', () => {
+    it('renames GAMEID directories and rewrites key template files', async () => {
+      const projectDir = path.join(tempDir, 'project');
+      const gameId = 'GLZE01';
+
+      await fs.mkdir(path.join(projectDir, 'orig', 'GAMEID'), { recursive: true });
+      await fs.mkdir(path.join(projectDir, 'config', 'GAMEID'), { recursive: true });
+
+      await fs.writeFile(path.join(projectDir, 'configure.py'), 'VERSIONS = ["GAMEID"]\n');
+      await fs.writeFile(path.join(projectDir, 'config', 'GAMEID', 'config.yml'), 'object_base: orig/GAMEID\n');
+      await fs.writeFile(
+        path.join(projectDir, 'config', 'GAMEID', 'config.example.yml'),
+        'symbols: config/GAMEID/symbols.txt\n',
+      );
+      await fs.writeFile(path.join(projectDir, 'config', 'GAMEID', 'build.sha1'), '0123  build/GAMEID/main.dol\n');
+
+      await customizeDtkTemplateProject(projectDir, gameId);
+
+      await expect(fs.stat(path.join(projectDir, 'orig', gameId))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(projectDir, 'config', gameId))).resolves.toBeDefined();
+      await expect(fs.access(path.join(projectDir, 'orig', 'GAMEID'))).rejects.toBeTruthy();
+      await expect(fs.access(path.join(projectDir, 'config', 'GAMEID'))).rejects.toBeTruthy();
+
+      const configurePy = await fs.readFile(path.join(projectDir, 'configure.py'), 'utf-8');
+      const configYml = await fs.readFile(path.join(projectDir, 'config', gameId, 'config.yml'), 'utf-8');
+      const configExample = await fs.readFile(path.join(projectDir, 'config', gameId, 'config.example.yml'), 'utf-8');
+      const buildSha = await fs.readFile(path.join(projectDir, 'config', gameId, 'build.sha1'), 'utf-8');
+
+      expect(configurePy).toContain(gameId);
+      expect(configurePy).not.toContain('GAMEID');
+      expect(configYml).toContain(`orig/${gameId}`);
+      expect(configYml).not.toContain('GAMEID');
+      expect(configExample).toContain(`config/${gameId}/symbols.txt`);
+      expect(buildSha).toContain(`build/${gameId}/main.dol`);
+    });
+  });
+});

--- a/src/cli/toolkit-init.ts
+++ b/src/cli/toolkit-init.ts
@@ -1,0 +1,196 @@
+import { execFile } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const DTK_TEMPLATE_REPO_URL = 'https://github.com/encounter/dtk-template.git';
+
+export type SupportedToolkit = 'dtk';
+export type DtkPlatform = 'gc' | 'wii';
+
+export interface ToolkitInitCliOptions {
+  initToolkit?: SupportedToolkit;
+  projectDir?: string;
+  gameId?: string;
+  platform?: DtkPlatform;
+}
+
+interface DtkInitRequest {
+  toolkit: 'dtk';
+  projectDir: string;
+  gameId: string;
+  platform: DtkPlatform;
+}
+
+export interface ToolkitInitSummary {
+  toolkit: 'dtk';
+  templateRepo: string;
+  projectDir: string;
+  gameId: string;
+  platform: DtkPlatform;
+  nextSteps: string[];
+}
+
+export class ToolkitInitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ToolkitInitError';
+  }
+}
+
+export function parseToolkitInitRequest(opts: ToolkitInitCliOptions): DtkInitRequest | null {
+  const hasToolkitArgs = !!(opts.initToolkit || opts.projectDir || opts.gameId || opts.platform);
+  if (!hasToolkitArgs) {
+    return null;
+  }
+
+  if (!opts.initToolkit) {
+    throw new ToolkitInitError('Toolkit init options (--project-dir/--game-id/--platform) require --init-toolkit dtk.');
+  }
+
+  if (opts.initToolkit !== 'dtk') {
+    throw new ToolkitInitError(`Unsupported toolkit: ${opts.initToolkit}`);
+  }
+
+  if (!opts.gameId) {
+    throw new ToolkitInitError('Missing required option for dtk scaffolding: --game-id (example: GLZE01).');
+  }
+
+  const gameId = opts.gameId.trim().toUpperCase();
+  if (!/^[A-Z0-9_]{4,16}$/.test(gameId)) {
+    throw new ToolkitInitError(`Invalid game ID '${opts.gameId}'. Expected 4-16 characters matching [A-Z0-9_].`);
+  }
+
+  const projectDir = opts.projectDir?.trim() || `./${gameId.toLowerCase()}-dtk`;
+  const platform = opts.platform ?? 'gc';
+
+  return {
+    toolkit: 'dtk',
+    projectDir,
+    gameId,
+    platform,
+  };
+}
+
+export async function maybeRunToolkitInit(
+  opts: ToolkitInitCliOptions,
+  onStatus?: (message: string) => void,
+): Promise<ToolkitInitSummary | null> {
+  const request = parseToolkitInitRequest(opts);
+  if (!request) {
+    return null;
+  }
+
+  if (request.toolkit !== 'dtk') {
+    throw new ToolkitInitError(`Unsupported toolkit: ${request.toolkit}`);
+  }
+
+  onStatus?.(
+    `Scaffolding decomp-toolkit project (${request.platform.toUpperCase()}) at ${path.resolve(request.projectDir)}...`,
+  );
+  return scaffoldDtkProject(request);
+}
+
+async function scaffoldDtkProject(request: DtkInitRequest): Promise<ToolkitInitSummary> {
+  const projectDir = path.resolve(request.projectDir);
+  await ensureDestinationDoesNotExist(projectDir);
+  await fs.mkdir(path.dirname(projectDir), { recursive: true });
+
+  await runCommand('git', ['clone', '--depth', '1', DTK_TEMPLATE_REPO_URL, projectDir], process.cwd());
+
+  try {
+    await fs.rm(path.join(projectDir, '.git'), { recursive: true, force: true });
+    await customizeDtkTemplateProject(projectDir, request.gameId);
+    await initializeGitRepo(projectDir);
+  } catch (error) {
+    throw new ToolkitInitError(
+      `decomp-toolkit scaffold created at ${projectDir}, but customization failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  return {
+    toolkit: 'dtk',
+    templateRepo: DTK_TEMPLATE_REPO_URL,
+    projectDir,
+    gameId: request.gameId,
+    platform: request.platform,
+    nextSteps: buildDtkNextSteps(projectDir, request.gameId, request.platform),
+  };
+}
+
+async function ensureDestinationDoesNotExist(projectDir: string): Promise<void> {
+  try {
+    await fs.access(projectDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+
+  throw new ToolkitInitError(`Destination already exists: ${projectDir}`);
+}
+
+async function initializeGitRepo(projectDir: string): Promise<void> {
+  try {
+    await runCommand('git', ['init', '-b', 'main'], projectDir);
+  } catch {
+    await runCommand('git', ['init'], projectDir);
+  }
+}
+
+async function runCommand(command: string, args: string[], cwd: string): Promise<void> {
+  try {
+    await execFileAsync(command, args, { cwd });
+  } catch (error) {
+    const execError = error as NodeJS.ErrnoException & { stderr?: string };
+    const details = execError.stderr?.trim() || execError.message;
+    throw new ToolkitInitError(`Failed to run '${command} ${args.join(' ')}': ${details}`);
+  }
+}
+
+export async function customizeDtkTemplateProject(projectDir: string, gameId: string): Promise<void> {
+  const originalGameId = 'GAMEID';
+  const origSource = path.join(projectDir, 'orig', originalGameId);
+  const origDest = path.join(projectDir, 'orig', gameId);
+  const configSource = path.join(projectDir, 'config', originalGameId);
+  const configDest = path.join(projectDir, 'config', gameId);
+
+  await fs.rename(origSource, origDest);
+  await fs.rename(configSource, configDest);
+
+  const filesToRewrite = [
+    path.join(projectDir, 'configure.py'),
+    path.join(configDest, 'config.yml'),
+    path.join(configDest, 'config.example.yml'),
+    path.join(configDest, 'build.sha1'),
+  ];
+
+  await Promise.all(filesToRewrite.map((filePath) => replaceInFile(filePath, originalGameId, gameId)));
+}
+
+async function replaceInFile(filePath: string, searchValue: string, replacementValue: string): Promise<void> {
+  const content = await fs.readFile(filePath, 'utf-8');
+  if (!content.includes(searchValue)) {
+    return;
+  }
+  await fs.writeFile(filePath, content.replaceAll(searchValue, replacementValue));
+}
+
+function buildDtkNextSteps(projectDir: string, gameId: string, platform: DtkPlatform): string[] {
+  const relativeProjectDir = path.relative(process.cwd(), projectDir);
+  const displayProjectDir =
+    !relativeProjectDir || relativeProjectDir.startsWith('..') ? projectDir : relativeProjectDir;
+
+  return [
+    `Extract the game disc contents into orig/${gameId} (Dolphin can extract GC/Wii discs).`,
+    `Edit config/${gameId}/config.yml to match your game and linker settings (mw_comment_version, modules, maps).`,
+    `Generate hashes with: dtk shasum orig/${gameId}/sys/main.dol orig/${gameId}/files/*.rel -o config/${gameId}/build.sha1`,
+    `Run initial analysis: cd ${displayProjectDir} && python3 configure.py && ninja`,
+    `When you create mizuchi.yaml for this project, set global.target to '${platform}'.`,
+  ];
+}

--- a/src/commands/index.tsx
+++ b/src/commands/index.tsx
@@ -12,6 +12,7 @@ import {
   loadConfigFile,
   validatePaths,
 } from '~/cli/config.js';
+import { type ToolkitInitSummary, maybeRunToolkitInit } from '~/cli/toolkit-init.js';
 import { PluginManager } from '~/plugin-manager.js';
 import {
   ClaudeRunnerConfig,
@@ -59,6 +60,22 @@ export const options = z.object({
     .string()
     .optional()
     .describe(option({ description: 'Output directory for generated files and report', alias: 'o' })),
+  initToolkit: z
+    .enum(['dtk'])
+    .optional()
+    .describe(option({ description: 'Scaffold a decomp project toolkit (experimental). Currently supports: dtk' })),
+  projectDir: z
+    .string()
+    .optional()
+    .describe(option({ description: 'Destination directory for toolkit scaffolding (used with --init-toolkit)' })),
+  gameId: z
+    .string()
+    .optional()
+    .describe(option({ description: 'Game ID for toolkit scaffolding, e.g. GLZE01 (used with --init-toolkit)' })),
+  platform: z
+    .enum(['gc', 'wii'])
+    .optional()
+    .describe(option({ description: 'Console target for toolkit scaffolding (GC/Wii). Default: gc' })),
 });
 
 type Props = {
@@ -82,6 +99,7 @@ interface PluginStatus {
 interface ProgressState {
   phase: 'loading' | 'initializing' | 'running' | 'complete' | 'error';
   currentFlow: 'loading' | 'programmatic-flow' | 'ai-powered-flow';
+  loadingMessage?: string;
   config?: PipelineConfig;
   plugins: PluginInfo[];
   // Current prompt info
@@ -118,6 +136,7 @@ interface ProgressState {
   // Final results
   results?: PipelineResults;
   htmlReportPath?: string;
+  toolkitInitSummary?: ToolkitInitSummary;
   // Error message
   errorMessage?: string;
   // Active interactive prompt
@@ -131,6 +150,7 @@ export default function Index({ options: opts }: Props) {
   const [state, setState] = useState<ProgressState>({
     phase: 'loading',
     currentFlow: 'loading',
+    loadingMessage: 'Loading configuration...',
     plugins: [],
     pluginStatuses: [],
     completedPrompts: [],
@@ -346,7 +366,7 @@ export default function Index({ options: opts }: Props) {
       {state.phase === 'loading' && (
         <Box>
           <Text color="yellow">
-            <Spinner type="dots" /> Loading configuration...
+            <Spinner type="dots" /> {state.loadingMessage ?? 'Loading configuration...'}
           </Text>
         </Box>
       )}
@@ -459,6 +479,10 @@ export default function Index({ options: opts }: Props) {
       )}
 
       {/* Complete phase */}
+      {state.phase === 'complete' && state.toolkitInitSummary && (
+        <ToolkitInitSummaryView summary={state.toolkitInitSummary} />
+      )}
+
       {state.phase === 'complete' && state.results && (
         <PipelineSummary results={state.results} htmlReportPath={state.htmlReportPath} />
       )}
@@ -644,6 +668,40 @@ function PipelineSummary({ results, htmlReportPath }: { results: PipelineResults
   );
 }
 
+function ToolkitInitSummaryView({ summary }: { summary: ToolkitInitSummary }) {
+  return (
+    <Box flexDirection="column">
+      <Text color="green" bold>
+        Toolkit Scaffold Complete
+      </Text>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text>
+          Toolkit: <Text bold>{summary.toolkit}</Text>
+        </Text>
+        <Text>
+          Platform: <Text bold>{summary.platform}</Text>
+        </Text>
+        <Text>
+          Game ID: <Text bold>{summary.gameId}</Text>
+        </Text>
+        <Text>
+          Project Dir: <Text bold>{summary.projectDir}</Text>
+        </Text>
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Next steps:</Text>
+        {summary.nextSteps.map((step, index) => (
+          <Text key={step} dimColor>
+            {index + 1}. {step}
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
 async function runPipeline(
   opts: z.infer<typeof options>,
   onEvent: (event: PipelineEvent) => void,
@@ -669,6 +727,33 @@ async function runPipeline(
   let backgroundCoordinator: BackgroundTaskCoordinator | undefined;
 
   try {
+    const toolkitInitSummary = await maybeRunToolkitInit(opts, (message) => {
+      setState((prev) => ({
+        ...prev,
+        phase: 'loading',
+        currentFlow: 'loading',
+        loadingMessage: message,
+      }));
+    });
+
+    if (toolkitInitSummary) {
+      setState((prev) => ({
+        ...prev,
+        phase: 'complete',
+        currentFlow: 'loading',
+        toolkitInitSummary,
+        loadingMessage: undefined,
+      }));
+
+      setTimeout(() => {
+        process.exit(0);
+      }, 1);
+
+      return;
+    }
+
+    setState((prev) => ({ ...prev, loadingMessage: 'Loading configuration...' }));
+
     // Load configuration from file (if exists)
     const configPath = getConfigFilePath(opts.config);
     const fileConfig = await loadConfigFile(configPath);


### PR DESCRIPTION
## Summary
- add an experimental CLI scaffold mode for GC/Wii projects using decomp-toolkit's dtk-template
- 
## Notes
- this is just DTK since I dont know of any real GBA toolkits. Would love to add those as well

## Validation
- npm test -- src/cli/toolkit-init.spec.ts
- npm run check-types
- smoke tested: npm run dev -- --init-toolkit dtk --game-id GLZE01 --platform gc --project-dir /tmp/...